### PR TITLE
Fix config importing when configdir is not first in path

### DIFF
--- a/patch.d/config.multiconfig.py.patch
+++ b/patch.d/config.multiconfig.py.patch
@@ -1,5 +1,5 @@
---- ./MoinMoin/config/multiconfig.py.orig	2012-12-29 21:06:54.000000000 +0200
-+++ ./MoinMoin/config/multiconfig.py	2014-11-28 10:52:58.515259865 +0200
+--- ./MoinMoin/config/multiconfig.py.orig	2014-10-17 22:45:32.000000000 +0300
++++ ./MoinMoin/config/multiconfig.py	2016-08-15 20:40:10.791108505 +0300
 @@ -12,6 +12,7 @@ import re
  import os
  import sys
@@ -8,21 +8,39 @@
  
  from MoinMoin import log
  logging = log.getLogger(__name__)
-@@ -45,7 +46,16 @@ def _importConfigModule(name):
+@@ -34,6 +35,25 @@ _farmconfig_mtime = None
+ _config_cache = {}
+ 
+ 
++def _findConfigModule(name):
++    """ Try to find config module or raise ImportError
++
++    Return first module found in a file, skipping packages with
++    colliding names.
++    """
++    for path in sys.path:
++        if not path:
++            continue
++        try:
++            fp, pathname, description = imp.find_module(name, [path])
++            if not fp:
++                continue
++            return fp, pathname, description
++        except ImportError:
++            continue
++    raise ImportError('No module named %s' % name)
++
++
+ def _importConfigModule(name):
+     """ Import and return configuration module and its modification time
+ 
+@@ -45,7 +65,8 @@ def _importConfigModule(name):
      @return: module, modification time
      """
      try:
 -        module = __import__(name, globals(), {})
-+        configdir = None
-+        for entry in sys.path:
-+            if not entry:
-+                continue
-+            if entry.endswith('MoinMoin/support'):
-+                continue
-+            configdir = [entry]
-+            break
-+        _file, pathname, description = imp.find_module(name, configdir)
-+        module = imp.load_module(name, _file, pathname, description)
++        fp, pathname, description = _findConfigModule(name)
++        module = imp.load_module(name, fp, pathname, description)
          mtime = os.path.getmtime(module.__file__)
      except ImportError:
          raise

--- a/patch.d/config.multiconfig.py.patch
+++ b/patch.d/config.multiconfig.py.patch
@@ -1,5 +1,5 @@
 --- ./MoinMoin/config/multiconfig.py.orig	2014-10-17 22:45:32.000000000 +0300
-+++ ./MoinMoin/config/multiconfig.py	2016-08-15 20:40:10.791108505 +0300
++++ ./MoinMoin/config/multiconfig.py	2016-08-15 22:34:12.813289705 +0300
 @@ -12,6 +12,7 @@ import re
  import os
  import sys
@@ -15,7 +15,7 @@
 +def _findConfigModule(name):
 +    """ Try to find config module or raise ImportError
 +
-+    Return first module found in a file, skipping packages with
++    Return first module that is a single file, skipping packages with
 +    colliding names.
 +    """
 +    for path in sys.path:


### PR DESCRIPTION
The config directory is not always first in sys.path, e.g. when set by PYTHONPATH environment variable on the command line or when namespace packages are used. Instead, try to find the first module that is a single file, skipping packages with colliding names.
